### PR TITLE
Enforce minimum distance for enemy spawns

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -1,5 +1,7 @@
 // Enemy logic goes here
 
+const MIN_SPAWN_DISTANCE = 150;
+
 export class Enemy {
     constructor(worldX, y, width = 40, height = 40) {
         this.worldX = worldX;
@@ -153,11 +155,16 @@ export class EnemyManager {
     spawnEnemy(canvas, worldX, player, gate, boss, testLevelEndX) {
         const playerWorldX = player.x - worldX;
         if (gate === null || boss || playerWorldX > testLevelEndX - canvas.width) return;
-        
-        const spawnX = this.spawnFromRightNext ? 
-            -worldX + canvas.width + 50 : 
+
+        let spawnX = this.spawnFromRightNext ?
+            -worldX + canvas.width + 50 :
             -worldX - 50;
-            
+
+        const dx = spawnX - playerWorldX;
+        if (Math.abs(dx) < MIN_SPAWN_DISTANCE) {
+            spawnX = playerWorldX + Math.sign(dx || 1) * MIN_SPAWN_DISTANCE;
+        }
+
         const newEnemy = new Enemy(spawnX, canvas.height - 100);
         this.enemies.push(newEnemy);
     }

--- a/js/game.js
+++ b/js/game.js
@@ -3,6 +3,7 @@ import LevelManager from './levelManager.js';
 import { Quiz } from './quiz.js';
 import { Enemy, EnemyManager } from './enemy.js';
 
+        const MIN_SPAWN_DISTANCE = 150;
         const levelManager = new LevelManager();
         const canvas = document.getElementById('gameCanvas');
         const ctx = canvas.getContext('2d');
@@ -664,7 +665,11 @@ import { Enemy, EnemyManager } from './enemy.js';
                     const elapsed = Date.now() - platform.alarmTime;
                     if (elapsed > (platform.alarmDelay || 1000) && !platform.enemiesSpawned) {
                         // Spawn enemies near the alarm platform
-                        const spawnX = platform.worldX + platform.width + 100;
+                        let spawnX = platform.worldX + platform.width + 100;
+                        const playerWorldX = player.x - worldX;
+                        if (Math.abs(spawnX - playerWorldX) < MIN_SPAWN_DISTANCE) {
+                            spawnX = playerWorldX + Math.sign(spawnX - playerWorldX || 1) * MIN_SPAWN_DISTANCE;
+                        }
                         enemyManager.enemies.push({
                             worldX: spawnX,
                             y: platform.y - 40,

--- a/js/levelManager.js
+++ b/js/levelManager.js
@@ -1,5 +1,7 @@
 import { Enemy } from './enemy.js';
 
+const MIN_SPAWN_DISTANCE = 150;
+
 class LevelManager {
     constructor() {
         this.currentLevel = null;
@@ -344,8 +346,12 @@ class LevelManager {
                 wave.triggered = true;
 
                 wave.enemies.forEach(enemyDef => {
+                    let spawnX = enemyDef.x;
+                    if (Math.abs(spawnX - playerWorldX) < MIN_SPAWN_DISTANCE) {
+                        spawnX = playerWorldX + Math.sign(spawnX - playerWorldX || 1) * MIN_SPAWN_DISTANCE;
+                    }
                     const newEnemy = new Enemy(
-                        enemyDef.x,
+                        spawnX,
                         this.parsePosition(enemyDef.y, canvas)
                     );
                     newEnemy.hp = enemyDef.hp || 1;


### PR DESCRIPTION
## Summary
- add MIN_SPAWN_DISTANCE constant
- adjust enemy, level, and alarm spawns to ensure enemies appear away from player

## Testing
- `node --check js/enemy.js`
- `node --check js/levelManager.js`
- `node --check js/game.js`
- `npm test` *(fails: enoent)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e5e73a90832d97d5984b9ec53519