### PR TITLE
Tighten pits for baseline path traversal

### DIFF
--- a/js/levels/level_0.js
+++ b/js/levels/level_0.js
@@ -109,11 +109,11 @@ const level = {
         { type: 'pit', x: 2700, width: 150 }, // **FIX**: Narrowed from 200 to 150 to prevent glitchy double jump
         { type: 'pit', x: 3300, width: 150 },
         // **FIX**: Reduced from 550px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 4500, width: 250 }, 
+        { type: 'pit', x: 4500, width: 200 },
         { type: 'pit', x: 6200, width: 250 },
         // **FIX**: Split the 800px pit into two smaller pits with a platform between
-        { type: 'pit', x: 6900, width: 250 },
-        { type: 'pit', x: 7400, width: 250 }
+        { type: 'pit', x: 6900, width: 200 },
+        { type: 'pit', x: 7400, width: 200 }
     ],
     
     // Items (chests, pickups)

--- a/js/levels/level_1.js
+++ b/js/levels/level_1.js
@@ -57,7 +57,7 @@ const level = {
         
         // --- SECTION 4: BLOOD-BRAIN BARRIER ---
         // Puzzle platforms requiring specific medications
-        { id: 'barrier_platform_1', x: 4800, y: 'ground-200', width: 100, height: 20, type: 'static', activated: false },
+        { id: 'barrier_platform_1', x: 4800, y: 'ground-200', width: 100, height: 20, type: 'static', activated: true },
         { id: 'barrier_platform_2', x: 4950, y: 'ground-300', width: 100, height: 20, type: 'static', activated: false },
         { id: 'barrier_platform_3', x: 5100, y: 'ground-400', width: 100, height: 20, type: 'static', activated: false },
         
@@ -137,15 +137,15 @@ const level = {
     hazards: [
         { type: 'pit', x: 1450, width: 150 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 2400, width: 250 },
+        { type: 'pit', x: 2400, width: 200 },
         { type: 'pit', x: 3900, width: 100 },
         // **FIX**: Reduced from 300px to 250px to ensure it's jumpable
-        { type: 'pit', x: 4500, width: 250 },
+        { type: 'pit', x: 4500, width: 200 },
         { type: 'pit', x: 5850, width: 150 },
         // **FIX**: Reduced from 300px to 250px to ensure it's jumpable
-        { type: 'pit', x: 7700, width: 250 },
+        { type: 'pit', x: 7700, width: 200 },
         // **FIX**: Reduced from 300px to 250px to ensure it's jumpable
-        { type: 'pit', x: 8700, width: 250 }
+        { type: 'pit', x: 8700, width: 200 }
     ],
     
     // Special zones

--- a/js/levels/level_3.js
+++ b/js/levels/level_3.js
@@ -150,16 +150,16 @@ const level = {
         // Pits representing fall risks
         { type: 'pit', x: 1350, width: 150 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 2100, width: 250 },
+        { type: 'pit', x: 2100, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 3100, width: 250 },
+        { type: 'pit', x: 3100, width: 200 },
         // **FIX**: Reduced from 300px to 250px for consistency
-        { type: 'pit', x: 4300, width: 250 },
+        { type: 'pit', x: 4300, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 6100, width: 250 },
+        { type: 'pit', x: 6100, width: 200 },
         // **FIX**: Reduced from 550px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 6950, width: 250 },
-        { type: 'pit', x: 7950, width: 250 },
+        { type: 'pit', x: 6950, width: 200 },
+        { type: 'pit', x: 7950, width: 200 },
         
         // Falling objects (deactivatable by NPCs)
         { id: 'falling_object_1', type: 'falling_object', x: 2600, y: 'ground-500', 

--- a/js/levels/level_4.js
+++ b/js/levels/level_4.js
@@ -185,17 +185,17 @@ const level = {
     hazards: [
         { type: 'pit', x: 1100, width: 200 },
         // **FIX**: Reduced from 600px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 2200, width: 250 },
+        { type: 'pit', x: 2200, width: 200 },
         // **FIX**: Reduced from 600px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 3600, width: 250 },
+        { type: 'pit', x: 3600, width: 200 },
         // **FIX**: Reduced from 500px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 5000, width: 250 },
+        { type: 'pit', x: 5000, width: 200 },
         // **FIX**: Reduced from 700px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 6300, width: 250 },
+        { type: 'pit', x: 6300, width: 200 },
         // **FIX**: Reduced from 500px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 8000, width: 250 },
+        { type: 'pit', x: 8000, width: 200 },
         // **FIX**: Reduced from 500px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 9500, width: 250 },
+        { type: 'pit', x: 9500, width: 200 },
         
         // Thought bubbles (harmful if touched)
         { id: 'intrusive_thought_1', type: 'thought_bubble', x: 2000, y: 'ground-400', 

--- a/js/levels/level_5.js
+++ b/js/levels/level_5.js
@@ -187,18 +187,18 @@ const level = {
     // Hazards
     hazards: [
         // **FIX**: Reduced from 300px to 250px for consistency
-        { type: 'pit', x: 1200, width: 250 },
+        { type: 'pit', x: 1200, width: 200 },
         // **FIX**: Reduced from 600px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 2400, width: 250 },
+        { type: 'pit', x: 2400, width: 200 },
         // **FIX**: Reduced from 300px to 250px for consistency
-        { type: 'pit', x: 4200, width: 250 },
+        { type: 'pit', x: 4200, width: 200 },
         // **FIX**: Reduced from 500px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 5500, width: 250 },
+        { type: 'pit', x: 5500, width: 200 },
         { type: 'pit', x: 7200, width: 200 },
         // **FIX**: Reduced from 300px to 250px for consistency
-        { type: 'pit', x: 8500, width: 250 },
+        { type: 'pit', x: 8500, width: 200 },
         // **FIX**: Reduced from 300px to 250px for consistency
-        { type: 'pit', x: 9700, width: 250 },
+        { type: 'pit', x: 9700, width: 200 },
         
         // Pressure ulcer zones (damage if stay too long)
         { id: 'pressure_zone_1', type: 'pressure_ulcer', x: 3400, y: 'ground-0', 

--- a/js/levels/level_6.js
+++ b/js/levels/level_6.js
@@ -205,17 +205,17 @@ const level = {
     hazards: [
         { type: 'pit', x: 1300, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 2600, width: 250 },
+        { type: 'pit', x: 2600, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 4100, width: 250 },
+        { type: 'pit', x: 4100, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 5600, width: 250 },
+        { type: 'pit', x: 5600, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 7100, width: 250 },
+        { type: 'pit', x: 7100, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 8600, width: 250 },
+        { type: 'pit', x: 8600, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 10100, width: 250 },
+        { type: 'pit', x: 10100, width: 200 },
         
         // Acid-base imbalance zones
         { id: 'acidosis_zone', type: 'pH_hazard', x: 7800, y: 'ground-0', 

--- a/js/levels/level_7.js
+++ b/js/levels/level_7.js
@@ -211,21 +211,21 @@ const level = {
     // Hazards
     hazards: [
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 1600, width: 250 },
+        { type: 'pit', x: 1600, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 3100, width: 250 },
+        { type: 'pit', x: 3100, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 4600, width: 250 },
+        { type: 'pit', x: 4600, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 6100, width: 250 },
+        { type: 'pit', x: 6100, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 7600, width: 250 },
+        { type: 'pit', x: 7600, width: 200 },
         // **FIX**: Reduced from 300px to 250px for consistency
-        { type: 'pit', x: 9100, width: 250 },
+        { type: 'pit', x: 9100, width: 200 },
         // **FIX**: Reduced from 400px to 250px to make it jumpable without NPC help
-        { type: 'pit', x: 10600, width: 250 },
+        { type: 'pit', x: 10600, width: 200 },
         // **FIX**: Reduced from 300px to 250px for consistency
-        { type: 'pit', x: 11900, width: 250 },
+        { type: 'pit', x: 11900, width: 200 },
         
         // Lifecycle-specific hazards
         { id: 'teratogen_1', type: 'teratogen', x: 900, y: 'ground-300', 


### PR DESCRIPTION
## Summary
- Narrow oversized pits across levels 0 and 1-7 to ensure base traversal is possible without quiz interactions
- Enable barrier platform in level 1 so the blood-brain barrier can be crossed without activation

## Testing
- `node validate-levels.mjs` (manual) confirming all levels now valid
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a93cad7658832dbe8c20e18b4f762b