### PR TITLE
Fix NPC question freeze without activation targets

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -151,13 +151,15 @@ import {
                 const currentQuestion = quiz.getCurrentQuestion();
                 if (currentQuestion.answered) {
                     if (currentQuestion.isCorrect) {
-                        const activationIds = currentQuestion.interactionId.split(',');
-                        activationIds.forEach(id => {
-                            const targetPlatform = platforms.find(p => p.id === id);
-                            if (targetPlatform) {
-                                targetPlatform.activated = true;
-                            }
-                        });
+                        if (currentQuestion.interactionId) {
+                            const activationIds = currentQuestion.interactionId.split(',');
+                            activationIds.forEach(id => {
+                                const targetPlatform = platforms.find(p => p.id === id);
+                                if (targetPlatform) {
+                                    targetPlatform.activated = true;
+                                }
+                            });
+                        }
 
                         // Handle chest opening
                         const targetChest = chests.find(c => c.id === currentQuestion.interactionId);
@@ -324,11 +326,8 @@ import {
         }
 
         function askQuestion(interactionId, originalId) {
-            quiz.askQuestion(interactionId);
-            // Set the originalInteractionId after the question is created
-            if (quiz.currentQuestion) {
-                quiz.currentQuestion.originalInteractionId = originalId;
-            }
+            // Pass both identifiers so the quiz system knows which object triggered the question
+            quiz.askQuestion(interactionId, originalId);
             gameState = 'quiz';
         }
 

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -30,7 +30,7 @@ export class Quiz {
     }
     
     // Get a random question and prepare it for display
-    askQuestion(interactionId) {
+    askQuestion(interactionId, originalInteractionId = null) {
         if (this.availableQuestions.length === 0) {
             this.availableQuestions = [...this.questionBank];
         }
@@ -49,9 +49,10 @@ export class Quiz {
             answered: false,
             isCorrect: false,
             playerAnswer: null,
-            interactionId: interactionId
+            interactionId: interactionId,
+            originalInteractionId: originalInteractionId
         };
-        
+
         return this.currentQuestion;
     }
     

--- a/js/systems/GameActions.js
+++ b/js/systems/GameActions.js
@@ -205,18 +205,20 @@ export class GameActions {
      * Handle correct quiz answer
      */
     handleCorrectAnswer(currentQuestion) {
-        // Activate platforms
-        const activationIds = currentQuestion.interactionId.split(',');
-        activationIds.forEach(id => {
-            const targetPlatform = this.gameState.platforms.find(p => p.id === id);
-            if (targetPlatform) {
-                targetPlatform.activated = true;
-            }
-        });
-        
+        // Activate platforms if any are specified
+        if (currentQuestion.interactionId) {
+            const activationIds = currentQuestion.interactionId.split(',');
+            activationIds.forEach(id => {
+                const targetPlatform = this.gameState.platforms.find(p => p.id === id);
+                if (targetPlatform) {
+                    targetPlatform.activated = true;
+                }
+            });
+        }
+
         // Handle chest rewards
         this.handleChestReward(currentQuestion);
-        
+
         // Handle NPC medication rewards
         this.handleNPCReward(currentQuestion);
     }


### PR DESCRIPTION
## Summary
- Prevent crash when NPC has no `activates` target by guarding `interactionId` checks
- Pass original interaction ids through quiz system and store them for reward handling
- Update core and system action flow to use new quiz API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa7ab4c874832d92919f12a26526f1