### PR TITLE
Reset level 4 psychological effects on death and add NPC protection rewards

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -432,10 +432,14 @@ import {
                     player.gravityFlipped = false;
                     player.tunnelVision = 0;
                     player.speedMultiplier = 1;
+                    player.depressionFog = 0;
 
                     // Apply active zone effects
                     for (const zone of levelManager.currentLevel.psychZones) {
                         if (playerWorldX >= zone.startX && playerWorldX <= zone.endX) {
+                            if (player.preventedEffects && player.preventedEffects.has(zone.effect)) {
+                                continue;
+                            }
                             switch(zone.effect) {
                                 case 'tunnel_vision':
                                     player.tunnelVision = zone.intensity;

--- a/js/levels/level_4.js
+++ b/js/levels/level_4.js
@@ -148,29 +148,35 @@ const level = {
     
     // NPCs - Mental health professionals
     npcs: [
-        { id: 'therapist_1', type: 'therapist', x: 1100, y: 'ground-60', 
-          dialogue: "Anxiety ahead. Remember: breathe deeply. Let me create safe spaces.", 
-          activates: 'breathing_space_1,breathing_space_2' },
+        { id: 'therapist_1', type: 'therapist', x: 1100, y: 'ground-60',
+          dialogue: "Anxiety ahead. Remember: breathe deeply. Let me create safe spaces.",
+          activates: 'breathing_space_1,breathing_space_2',
+          preventsEffect: 'tunnel_vision' },
         
-        { id: 'psychiatrist_1', type: 'psychiatrist', x: 2700, y: 'ground-60', 
-          dialogue: "Depression fog is thick here. Hold onto hope - I'll light the way.", 
-          activates: 'hope_bridge_1' },
+        { id: 'psychiatrist_1', type: 'psychiatrist', x: 2700, y: 'ground-60',
+          dialogue: "Depression fog is thick here. Hold onto hope - I'll light the way.",
+          activates: 'hope_bridge_1',
+          preventsEffect: 'darkness_slowness' },
         
-        { id: 'social_worker_1', type: 'social_worker', x: 4100, y: 'ground-60', 
-          dialogue: "Mania makes everything race. Let's find stability together.", 
-          activates: 'mood_stabilizer' },
+        { id: 'social_worker_1', type: 'social_worker', x: 4100, y: 'ground-60',
+          dialogue: "Mania makes everything race. Let's find stability together.",
+          activates: 'mood_stabilizer',
+          preventsEffect: 'speed_up' },
         
-        { id: 'counselor_1', type: 'counselor', x: 5400, y: 'ground-60', 
-          dialogue: "Confusion is temporary. Focus on my voice for clarity.", 
-          activates: 'clarity_path' },
+        { id: 'counselor_1', type: 'counselor', x: 5400, y: 'ground-60',
+          dialogue: "Confusion is temporary. Focus on my voice for clarity.",
+          activates: 'clarity_path',
+          preventsEffect: 'inverted_controls' },
         
-        { id: 'peer_support_1', type: 'peer_support', x: 6900, y: 'ground-60', 
-          dialogue: "I've been where you are. You're not alone. Stay grounded.", 
-          activates: 'grounding_reality' },
+        { id: 'peer_support_1', type: 'peer_support', x: 6900, y: 'ground-60',
+          dialogue: "I've been where you are. You're not alone. Stay grounded.",
+          activates: 'grounding_reality',
+          preventsEffect: 'mirror_twin' },
         
-        { id: 'crisis_counselor_1', type: 'crisis_counselor', x: 8400, y: 'ground-60', 
-          dialogue: "Reality feels broken, but it's still there. Let me anchor you.", 
-          activates: 'reality_anchor' },
+        { id: 'crisis_counselor_1', type: 'crisis_counselor', x: 8400, y: 'ground-60',
+          dialogue: "Reality feels broken, but it's still there. Let me anchor you.",
+          activates: 'reality_anchor',
+          preventsEffect: 'upside_down' },
         
         { id: 'recovery_coach_1', type: 'recovery_coach', x: 10000, y: 'ground-60', 
           dialogue: "You've come so far! Recovery isn't linear, but you're doing it.", 

--- a/js/player.js
+++ b/js/player.js
@@ -46,6 +46,7 @@ export class Player {
         this.gravityFlipped = false;
         this.tunnelVision = 0;
         this.depressionFog = 0;
+        this.preventedEffects = new Set();
         
         // Armor system
         this.armors = [0];
@@ -109,7 +110,15 @@ export class Player {
         this.y = groundY - this.height;
         this.vx = 0;
         this.vy = 0;
-        
+
+        // Reset temporary zone effects
+        this.invertedControls = false;
+        this.hasTwin = false;
+        this.gravityFlipped = false;
+        this.tunnelVision = 0;
+        this.depressionFog = 0;
+        this.speedMultiplier = 1;
+
         // Clear medication effects on respawn
         this.medication.clearAll();
     }
@@ -290,6 +299,14 @@ export class Player {
         this.sizeScale = 1;
         this.width = 50;
         this.height = 92;
+
+        // Clear zone effects and preventions
+        this.invertedControls = false;
+        this.hasTwin = false;
+        this.gravityFlipped = false;
+        this.tunnelVision = 0;
+        this.depressionFog = 0;
+        this.preventedEffects.clear();
         
         // Clear subsystem state
         this.medication.clearAll();

--- a/js/systems/GameActions.js
+++ b/js/systems/GameActions.js
@@ -221,6 +221,9 @@ export class GameActions {
 
         // Handle NPC medication rewards
         this.handleNPCReward(currentQuestion);
+
+        // Handle NPC effect prevention rewards
+        this.handleNPCEffectPrevention(currentQuestion);
     }
     
     /**
@@ -288,6 +291,17 @@ export class GameActions {
                 width: 30,
                 height: 30
             });
+            interactingNpc.isLeaving = true;
+        }
+    }
+
+    /**
+     * Grant NPC effect prevention reward
+     */
+    handleNPCEffectPrevention(currentQuestion) {
+        const interactingNpc = this.gameState.npcs.find(n => n.interactionId === currentQuestion.originalInteractionId);
+        if (interactingNpc && interactingNpc.preventsEffect) {
+            this.player.preventedEffects.add(interactingNpc.preventsEffect);
             interactingNpc.isLeaving = true;
         }
     }


### PR DESCRIPTION
## Summary
- Clear tunnel vision, dark fog, and other mental health zone effects after player death
- Track and skip zone effects when an NPC grants protection for correct answers
- Allow level 4 NPCs to prevent their associated psychological effects

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acccbb7f8c832da9937230554b4c63