### PR TITLE
Refine evil twin behavior and visuals

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -144,10 +144,13 @@ export class EnemyManager {
         
         for (let j = this.enemies.length - 1; j >= 0; j--) {
             const enemy = this.enemies[j];
-            
+
             for (let i = projectiles.length - 1; i >= 0; i--) {
                 const proj = projectiles[i];
-                
+
+                // Ignore phantom projectiles from the evil twin
+                if (proj.isPhantom) continue;
+
                 if (enemy.checkProjectileHit(proj, worldX)) {
                     // Store enemy data before removing it for item drops
                     const destroyedEnemy = { ...enemy };

--- a/js/player.js
+++ b/js/player.js
@@ -69,7 +69,8 @@ export class Player {
             actionDuration: 0,
             fireTimer: 0,
             lastPlayerX: 0,
-            aggressionLevel: 1.0
+            aggressionLevel: 1.0,
+            crouching: false
         };
         this.gravityFlipped = false;
         this.tunnelVision = 0;


### PR DESCRIPTION
## Summary
- Render evil twin using a semi-transparent player sprite with crouch support
- Improve evil twin AI to jump, crouch, and occasionally cross sides while firing harmless projectiles
- Ignore phantom projectiles for enemy/boss collisions and remove them on player contact

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad47ad76d4832d8260913e6a6bc49f